### PR TITLE
Add a more convenient substitute function

### DIFF
--- a/src/Z3.jl
+++ b/src/Z3.jl
@@ -80,6 +80,11 @@ for op in [:+, :-, :*, :/, :^, :(==), :(!=), :(<=), :(>=), :(<), :(>), :&, :|, :
     end
 end
 
+substitute(ctx::Context, expr::E1, substs::AbstractVector{Tuple{E2,E2}}) where {E1 <: Expr, E2 <: Expr} = begin
+    a, b = zip(substs...)
+    substitute(expr, ExprVector(ctx, a), ExprVector(ctx, b))
+end
+
 # ------------------------------------------------------------------------------
 # Solver
 


### PR DESCRIPTION
Like in the Python bindings, this function takes a list of pairs of expressions.