### PR TITLE
Update dependencies.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,9 +8,9 @@ CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
 z3_jll = "1bc4e1ec-7839-5212-8f2f-0d16b7bd09bc"
 
 [compat]
-CxxWrap = "0.10.1"
-julia = "1.3"
-z3_jll = "4.8.8"
+CxxWrap = "0.12.0"
+julia = "1.6"
+z3_jll = "4.8.14"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Use z3_jll v4.8.14 and require julia 1.6. All supported platforms for which libcxxwrap works have binaries built.

Ref: https://github.com/JuliaPackaging/Yggdrasil/pull/4654