### PR TITLE
Update dependencies

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -9,13 +9,13 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 [[CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.0.5+0"
+version = "1.0.5+1"
 
 [[CxxWrap]]
 deps = ["Libdl", "MacroTools", "libcxxwrap_julia_jll"]
-git-tree-sha1 = "bf6b3005bf7435544f7cac0f0ec13e1fef67b190"
+git-tree-sha1 = "3345cb637ca1efb2ebf7f5145558522b92660d1f"
 uuid = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
-version = "0.13.4"
+version = "0.14.2"
 
 [[Dates]]
 deps = ["Printf"]
@@ -24,22 +24,22 @@ uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 [[GMP_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "781609d7-10c4-51f6-84f2-b8444358ff6d"
-version = "6.2.1+2"
+version = "6.2.1+6"
 
 [[JLLWrappers]]
-deps = ["Preferences"]
-git-tree-sha1 = "abc9885a7ca2052a736a600f7fa66209f96506e1"
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7e5d6779a1e09a36db2a7b6cff50942a0a7d0fca"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.4.1"
+version = "1.5.0"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [[MacroTools]]
 deps = ["Markdown", "Random"]
-git-tree-sha1 = "42324d08725e200c23d4dfb549e0d5d89dede2d2"
+git-tree-sha1 = "2fa9ee3e63fd3a4f7a9a4f4744a52f4856de82df"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.10"
+version = "0.5.13"
 
 [[Markdown]]
 deps = ["Base64"]
@@ -47,24 +47,21 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "7eb1686b4f04b82f96ed7a4ea5890a4f0c7a09f1"
+git-tree-sha1 = "00805cd429dcb4870060ff49ef443486c262e38e"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.4.0"
+version = "1.4.1"
 
 [[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [[Random]]
-deps = ["SHA", "Serialization"]
+deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 version = "0.7.0"
-
-[[Serialization]]
-uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
 [[TOML]]
 deps = ["Dates"]
@@ -76,12 +73,12 @@ uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [[libcxxwrap_julia_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "922c664611fa46d1a644f224de7318ddc0fab53c"
+git-tree-sha1 = "3d47ce071d272d2cae9d1bc449c261237e9784f7"
 uuid = "3eaa8342-bff7-56a5-9981-c04077f7cee7"
-version = "0.9.7+3"
+version = "0.11.2+0"
 
 [[z3_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "GMP_jll", "JLLWrappers", "Libdl", "libcxxwrap_julia_jll"]
-git-tree-sha1 = "bc76322268a08e64f680b86ae84a79cfce55d778"
+git-tree-sha1 = "f11919f24484ee9c355a846bbd15e8401c5d2fea"
 uuid = "1bc4e1ec-7839-5212-8f2f-0d16b7bd09bc"
-version = "4.12.1+0"
+version = "4.12.4+0"

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
 z3_jll = "1bc4e1ec-7839-5212-8f2f-0d16b7bd09bc"
 
 [compat]
-CxxWrap = "0.13.4"
+CxxWrap = "0.14.2"
 julia = "1.6"
 z3_jll = "4.12.1"
 

--- a/src/Z3.jl
+++ b/src/Z3.jl
@@ -12,7 +12,7 @@ if !isdefined(z3_jll, :libz3jl)
     error("Platform not supported")
 end
 
-@wrapmodule(z3_jll.libz3jl)
+@wrapmodule(z3_jll.get_libz3jl_path)
 
 function __init__()
     @initcxx


### PR DESCRIPTION
In particular, `CxxWrap` needs to be upgraded to be compatible with Julia 1.10 (see https://github.com/JuliaInterop/CxxWrap.jl/issues/379). Fixes #26 