### PR TITLE
start pbeq

### DIFF
--- a/src/Z3.jl
+++ b/src/Z3.jl
@@ -6,7 +6,7 @@ import Base: ==, !=, <, <=, >, >=
 import Base: +, *, -, /, ^
 export init_ctx, clear_ctx, Sort, DeclareSort, BoolSort, IntSort, BitVecSort, Float16Sort, Float32Sort, Float64Sort,
 BoolVal, IntVal, BitVecVal, Float32Val, Float64Val,
-Const, IntVar, BoolVar, FP, FuncDecl, And, Or, Not, If, Iff, Exists, Sort,
+Const, IntVar, BoolVar, FP, FuncDecl, And, Or, Not, If, Iff, Exists, Pbeq, Sort,
 Context, Solver, add, push, pop, check, CheckResult, model, assertions
 
 #---------#
@@ -233,6 +233,11 @@ end
 function Iff(t1::Expr, t2::Expr)
     ctx = t1.ctx
     return Expr(ctx, Z3_mk_iff(ref(ctx), as_ast(t1), as_ast(t2)))
+end
+
+function Pbeq(vars::Vector{Expr}, coeffs, k)
+    ctx = vars[1].ctx
+    return Expr(ctx, Z3_mk_pbeq(ref(ctx), length(vars), map(e -> as_ast(e), vars), coeffs, k) )
 end
 
 #--------#


### PR DESCRIPTION
Trying to wrap the pseudo boolean functions.

It works but you need the 32 bit thing in here:
```jl
julia> using Z3

       s = Solver()
       x = BoolVar("x")
       y = BoolVar("y")
       z = BoolVar("z")
       add(s,Pbeq([x, y, z], Int32[1, 2, 3], 4))
       check(s)
       model(s)
z -> true
y -> false
x -> true
```